### PR TITLE
Read-behind stale objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,27 @@ locking
 Wraps any loader function of the form `loader(id, callback)` to use
 an LRU cache and lock I/O operations across concurrent calls.
 
-    var Locking = require('@mapbox/locking');
-    var fs = require('fs');
-    var readFile = Locking(fs.readFile);
+```js
+var Locking = require('@mapbox/locking');
+var fs = require('fs');
+var readFile = Locking(fs.readFile);
 
-    // Reads file once, calls callback 10x.
-    for (var i = 0; i < 10; i++) {
-        readFile('./sample.txt', function(err, data) {
-            console.log(data);
-        });
-    }
+// Reads file once, calls callback 10x.
+for (var i = 0; i < 10; i++) {
+    readFile('./sample.txt', function(err, data) {
+        console.log(data);
+    });
+}
+```
+
+### Usage
+
+```js
+var options = {};
+var lockingReader = Locking(reader, options);
+```
+
+`options` is passed directly to `lru-cache` (https://github.com/isaacs/node-lru-cache/blob/f25bdae0b4bb0166a75fa01d664a3e3cece1ce98/README.md#options) allowing you to set the max age, max items, and other behaviors of the LRU cache.
+
+When `options.stale` is set to `true` the locking cache implements additional behavior to continue serving a stale item until the item has been refreshed in the background.
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,7 @@ for (var i = 0; i < 10; i++) {
 }
 ```
 
-### Usage
-
-```js
-var options = {};
-var lockingReader = Locking(reader, options);
-```
-
-`options` is passed directly to `lru-cache` (https://github.com/isaacs/node-lru-cache/blob/f25bdae0b4bb0166a75fa01d664a3e3cece1ce98/README.md#options) allowing you to set the max age, max items, and other behaviors of the LRU cache.
+`options` is passed directly to [lru-cache](https://github.com/isaacs/node-lru-cache/blob/f25bdae0b4bb0166a75fa01d664a3e3cece1ce98/README.md#options) allowing you to set the max age, max items, and other behaviors of the LRU cache.
 
 When `options.stale` is set to `true` the locking cache implements additional behavior to continue serving a stale item until the item has been refreshed in the background.
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,66 @@ function locking(loader, options) {
     var cache = require('lru-cache')(options);
     var locks = {};
     var cacheStats = { hit:0, miss:0, mchit:0, mcmiss:0 };
-    var cacher = function(id, callback) {
+    var cacher = options.stale ?
+        createStaleCacher(cache, locks, cacheStats, loader) :
+        createCacher(cache, locks, cacheStats, loader);
+    cacher.cacheStats = cacheStats;
+    cacher.cache = cache;
+    loaders.push(loader);
+    cachers.push(cacher);
+    return cacher;
+}
+
+function createStaleCacher(cache, locks, cacheStats, loader) {
+    return function(id, callback) {
+        // Stringify objects.
+        var key = JSON.stringify(id);
+
+        // Instance is in LRU cache.
+        var cached = cache.get(key);
+        if (cached) {
+            cacheStats.hit++;
+            // The retrieved version of the object is not stale.
+            if (cache.has(key)) {
+                return callback(null, cached);
+            // The retrieved version of the object was stale: return it and
+            // cache a fresh version of the object in the background.
+            //
+            // 1. Return it
+            // 2. Set it again in the cache so calls to the loader continue
+            //    receiving the stale version until the fresh one is loaded
+            // 3. Continue onto loading logic
+            } else {
+                callback(null, cached);
+                cache.set(key, cached);
+            }
+        } else {
+            // Previous instance creation is in progress (locking).
+            if (locks[key]) return locks[key].push(callback);
+
+            // Create a new lock.
+            locks[key] = [callback];
+        }
+
+        loader(id, function(err, instance) {
+            if (!err && instance) {
+                cacheStats.miss++;
+                cache.set(key, instance);
+            }
+
+            if (locks[key]) {
+                var q = locks[key];
+                delete locks[key];
+                for (var i = 0; i < q.length; i++) {
+                    q[i](err, instance);
+                }
+            }
+        });
+    };
+}
+
+function createCacher(cache, locks, cacheStats, loader) {
+    return function(id, callback) {
         // Stringify objects.
         var key = JSON.stringify(id);
 
@@ -52,9 +111,5 @@ function locking(loader, options) {
             }
         });
     };
-    cacher.cacheStats = cacheStats;
-    cacher.cache = cache;
-    loaders.push(loader);
-    cachers.push(cacher);
-    return cacher;
 }
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tape": "^4.5.1"
   },
   "scripts": {
-    "test": "eslint index.js && tape test.js"
+    "test": "eslint index.js && tape test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/cacher.test.js
+++ b/test/cacher.test.js
@@ -1,4 +1,4 @@
-var locking = require('./index.js');
+var locking = require('../index.js');
 var tape = require('tape');
 
 var doc = {};

--- a/test/staleCacher.test.js
+++ b/test/staleCacher.test.js
@@ -1,0 +1,127 @@
+var locking = require('../index.js');
+var tape = require('tape');
+
+var doc = {};
+
+var io = {};
+io['"a"'] = 0;
+io['"b"'] = 0;
+io['"err"'] = 0;
+
+// Simulates a read function of the form `read(id, callback)`
+var testRead = function(id, callback) {
+    setTimeout(function() {
+        io[JSON.stringify(id)]++;
+        var data = JSON.parse(JSON.stringify(doc));
+        data.id = id;
+        // This purposefully simulates an I/O source that passes an error
+        // object *and* futher args to the callback. While most I/O functions
+        // don't pass anything beyond an error on failures when they do we
+        // need to bypass caching.
+        if (id === 'err') {
+            callback(new Error('read fail'), data);
+        } else {
+            callback(null, data);
+        }
+    }, 100);
+};
+
+var reader = locking(testRead, { maxAge: 1e3, stale: true });
+
+tape('locking singletons', function(t) {
+    t.equal(reader, locking(testRead, { maxAge:1e3 }), 'singletons locking instances');
+    t.end();
+});
+
+
+tape('accepts object as id', function(t) {
+    reader({pathname:'/test'}, function(err, read) {
+        t.deepEqual(read, { id: { pathname: '/test' } }, 'returns read object');
+        t.end();
+    });
+});
+
+tape('passes errors', function(t) {
+    reader('err', function(err, read) {
+        t.equal(err.toString(), 'Error: read fail');
+        t.deepEqual(read, { id: 'err' });
+        t.deepEqual(io['"err"'], 1, 'iops: 1');
+        t.end();
+    });
+});
+
+tape('does not cache object on errors', function(t) {
+    reader('err', function(err, read) {
+        t.equal(err.toString(), 'Error: read fail');
+        t.deepEqual(read, { id: 'err' });
+        t.deepEqual(io['"err"'], 2, 'iops: 2');
+        t.end();
+    });
+});
+
+tape('locks io for multiple calls', function(t) {
+    var hits = reader.cacheStats.hit;
+    var remaining = 10;
+    var data;
+    for (var i = 0; i < 10; i++) {
+        reader('a', function(err, read) {
+            if (!data) {
+                data = read;
+            } else {
+                t.deepEqual(data, read, 'data is shared amongst locked reader callbacks');
+            }
+            if (!--remaining) {
+                t.equal(reader.cacheStats.hit - hits, 0, '0 LRU cache hits');
+                t.equal(io['"a"'], 1, 'single I/O operation for a');
+                t.end();
+            }
+        });
+    }
+});
+
+tape('uses LRU for subsequent calls', function(t) {
+    var hits = reader.cacheStats.hit;
+    reader('b', function(err, data) {
+        var remaining = 10;
+        for (var i = 0; i < 10; i++) {
+            reader('b', function(err, read) {
+                t.deepEqual(data, read, 'data is shared amongst locked reader callbacks');
+                if (!--remaining) {
+                    t.equal(reader.cacheStats.hit - hits, 10, '10 LRU cache hits');
+                    t.equal(io['"b"'], 1, 'single I/O operation for b');
+                    t.end();
+                }
+            });
+        }
+    });
+});
+
+tape('stale step 1', function(t) {
+    reader('b', function(err, read) {
+        t.deepEqual(read, {id:'b'}, 'reads cached doc');
+        t.ok(true, 'update doc');
+        doc.extra = true;
+        setTimeout(t.end, 1500);
+    });
+});
+
+tape('stale step 2 (while background refresh is occurring)', function(t) {
+    reader('b', function(err, read) {
+        t.deepEqual(read, {id:'b'}, 'reads stale doc');
+    });
+    reader('b', function(err, read) {
+        t.deepEqual(read, {id:'b'}, 'reads stale doc');
+    });
+    reader('b', function(err, read) {
+        t.deepEqual(read, {id:'b'}, 'reads stale doc');
+        setTimeout(t.end, 200);
+    });
+});
+
+tape('stale step 3 (after background refresh is complete)', function(t) {
+    reader('b', function(err, read) {
+        t.deepEqual(read, {id:'b', extra:true}, 'reads updated doc');
+        t.end();
+    });
+});
+


### PR DESCRIPTION
Implements additional handling around `options.stale` (already an `lru-cache` option). Upstream this returns a stale object _once_ when requested from the LRU cache. In addition to just passing this option through `node-locking` implements:

- A background refresh of that object from the loader,
- Re-setting that stale object in the cache so that the cache can serve the stale object more than just once while the background refresh is in progress

Adds unit tests + documentation in README for this behavior as well.

