### PR TITLE
check if locks[key] exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,10 +105,12 @@ function createCacher(cache, locks, cacheStats, loader) {
                 cache.set(key, instance);
             }
 
-            var q = locks[key];
-            delete locks[key];
-            for (var i = 0; i < q.length; i++) {
-                q[i](err, instance);
+            if (locks[key]) {
+                var q = locks[key];
+                delete locks[key];
+                for (var i = 0; i < q.length; i++) {
+                    q[i](err, instance);
+                }
             }
         });
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/locking",
-  "version": "3.2.0",
+  "version": "3.3.0-dev1",
   "description": "Read I/O locking using LRU cache",
   "author": {
     "name": "Mapbox",


### PR DESCRIPTION
**TL;DR** attempt to fix `length of undefined` problem

This PR is related to an error message `TypeError: Cannot read property 'length' of undefined`. 
When I looked at the error logs more closely, it is complaining [this part](https://github.com/mapbox/locking/blob/f674ffb84f7ffae03810f2514df5f131ab6e330c/index.js#L110) of the code where it thinks **`q` is undefined**. 
Therefore, I added the same check `if (locks[key])` which is already written [in createStaleCacher()](https://github.com/mapbox/locking/blob/f674ffb84f7ffae03810f2514df5f131ab6e330c/index.js#L73) to make sure we don't try to query an object of undefined.

## Related PRs
- https://github.com/mapbox/api-gl/issues/1128
- https://github.com/mapbox/api-gl/pull/1139#issuecomment-459341073
- https://github.com/mapbox/api-gl/pull/1139#issuecomment-461108019

/cc @mapbox/maps-api 